### PR TITLE
Stop allowing flags to be left clicked

### DIFF
--- a/board.py
+++ b/board.py
@@ -184,6 +184,9 @@ class Board:
 
         if self._inside_board(realx, realy):
             tile = self.grid[realx][realy]
+            if tile.flagged:
+                return True
+
             if tile.type == TileType.Mine:
                 tile.type = TileType.Detonation
                 return False


### PR DESCRIPTION
    When flags are leftclicked they
    behaved as if they were normal tiles
    now they are not clickable.

closes: #1 